### PR TITLE
v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ A **TypeScript** type definitions package for affix.
       - [`BasicAffixKind`](#basicaffixkind)
       - [`HypotheticalAffixKind`](#hypotheticalaffixkind)
       - [`SuprasegmentalAffixKind`](#suprasegmentalaffixkind)
-
     - [`AdfixTuple`](#adfixtuple)
-
     - Template
       - [`AdfixTemplate`](#adfixtemplate)
       - [`CircumfixTemplate`](#circumfixtemplate)
@@ -111,6 +109,12 @@ const affixConfiguration1: AffixConfiguration<'example', 'circumfix', 27> = {
   length: 27,
   pattern: /^[a-zA-Z]+$/,
   timestamp: new Date(),
+  digit: false,
+  lowercase: true,
+  uppercase: true,
+  special: true,
+  whitespace: false,
+  numeric: false,
 };
 
 // Full configuration with length and pattern settings.
@@ -122,13 +126,14 @@ const affixConfiguration2: AffixConfiguration<'example', 'prefix', 27, 27, 34> =
     min: 27,
     max: 34 
   },
-  pattern: {
-    regexp: /^[a-zA-Z]+$/,
-    lowercase: true,
-    uppercase: true,
-    special: true,
-  },
+  pattern: /^[a-zA-Z]+$/,
   timestamp: new Date(),
+  digit: false,
+  lowercase: true,
+  uppercase: true,
+  special: true,
+  whitespace: false,
+  numeric: false,
 };
 ```
 
@@ -192,12 +197,13 @@ const settings1: AffixSettings<'example', 'infix', 33, 27, 34, RegExp> = {
     min: 27,
     max: 34 
   },
-  pattern: {
-    regexp: /^[a-zA-Z]+$/,
-    lowercase: true,
-    uppercase: true,
-    special: true,
-  },
+  pattern: /^[a-zA-Z]+$/,
+  digit: false,
+  lowercase: true,
+  uppercase: true,
+  special: true,
+  whitespace: false,
+  numeric: false,
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,22 @@ A **TypeScript** type definitions package for affix.
     - [`AffixOptions`](#affixoptions)
     - [`AffixSettings`](#affixsettings)
   - [Type](#type)
-    - [`Adfix`](#adfix)
-    - [`AdfixTemplate`](#adfixtemplate)
+    - Kind
+      - [`Adfix`](#adfix)
+      - [`AffixKind`](#affixkind)
+      - [`BasicAffixKind`](#basicaffixkind)
+      - [`HypotheticalAffixKind`](#hypotheticalaffixkind)
+      - [`SuprasegmentalAffixKind`](#suprasegmentalaffixkind)
+
     - [`AdfixTuple`](#adfixtuple)
-    - [`AffixKind`](#affixkind)
-    - [`BasicAffixKind`](#basicaffixkind)
-    - [`HypotheticalAffixKind`](#hypotheticalaffixkind)
-    - [`SuprasegmentalAffixKind`](#suprasegmentalaffixkind)
+
+    - Template
+      - [`AdfixTemplate`](#adfixtemplate)
+      - [`CircumfixTemplate`](#circumfixtemplate)
+      - [`InfixTemplate`](#infixtemplate)
+      - [`InterfixTemplate`](#interfixtemplate)
+      - [`PrefixTemplate`](#prefixtemplate)
+      - [`SuffixTemplate`](#suffixtemplate)
 - [Contributing](#contributing)
 - [Support](#support)
 - [Code of Conduct](#code-of-conduct)
@@ -66,14 +75,23 @@ import {
   AffixConstructor,
   AffixOptions,
   AffixSettings,
-  //Type.
+
+  // Type.
+  // -> Kind.
   Adfix,
-  AdfixTemplate,
-  AdfixTuple,
   AffixKind,
   BasicAffixKind,
   HypotheticalAffixKind,
   SuprasegmentalAffixKind,
+  // -> Tuple.
+  AdfixTuple,
+  // -> Template.
+  AdfixTemplate,
+  CircumfixTemplate,
+  InfixTemplate,
+  InterfixTemplate,
+  PrefixTemplate,
+  SuffixTemplate,
 } from '@typedly/affix';
 ```
 
@@ -193,22 +211,6 @@ const settings1: AffixSettings<'example', 'infix', 33, 27, 34, RegExp> = {
 import { Adfix } from '@typedly/affix';
 ```
 
-#### `AdfixTemplate`
-
-[`adfix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/adfix-template.type.ts)
-
-```typescript
-import { AdfixTemplate } from '@typedly/affix';
-```
-
-#### `AdfixTuple`
-
-[`adfix-tuple.type.ts`](https://github.com/typedly/affix/blob/main/src/type/adfix-tuple.type.ts)
-
-```typescript
-import { AdfixTuple } from '@typedly/affix';
-```
-
 #### `AffixKind`
 
 [`affix-kind.type.ts`](https://github.com/typedly/affix/blob/main/src/type/affix-kind.type.ts)
@@ -239,6 +241,66 @@ import { SuprasegmentalAffixKind } from '@typedly/affix';
 
 ```typescript
 import { HypotheticalAffixKind } from '@typedly/affix';
+```
+
+#### Tuple
+
+#### `AdfixTuple`
+
+[`adfix-tuple.type.ts`](https://github.com/typedly/affix/blob/main/src/type/adfix-tuple.type.ts)
+
+```typescript
+import { AdfixTuple } from '@typedly/affix';
+```
+
+#### Template
+
+#### `AdfixTemplate`
+
+[`adfix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/adfix-template.type.ts)
+
+```typescript
+import { AdfixTemplate } from '@typedly/affix';
+```
+
+#### `CircumfixTemplate`
+
+[`circumfix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/circumfix-template.type.ts)
+
+```typescript
+import { CircumfixTemplate } from '@typedly/affix';
+```
+
+#### `InfixTemplate`
+
+[`infix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/infix-template.type.ts)
+
+```typescript
+import { InfixTemplate } from '@typedly/affix';
+```
+
+#### `InterfixTemplate`
+
+[`interfix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/interfix-template.type.ts)
+
+```typescript
+import { InterfixTemplate } from '@typedly/affix';
+```
+
+#### `PrefixTemplate`
+
+[`prefix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/prefix-template.type.ts)
+
+```typescript
+import { PrefixTemplate } from '@typedly/affix';
+```
+
+#### `SuffixTemplate`
+
+[`prefix-template.type.ts`](https://github.com/typedly/affix/blob/main/src/type/suffix-template.type.ts)
+
+```typescript
+import { SuffixTemplate } from '@typedly/affix';
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![GitHub issues][typedly-badge-issues]][typedly-issues]
 [![GitHub license][typedly-badge-license]][typedly-license]
 
-**Version:** v3.0.0
+**Version:** v4.0.0
 
 A **TypeScript** type definitions package for affix.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typedly/affix",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@typedly/affix",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "funding": [
         {
           "type": "stripe",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,13 @@
       ],
       "license": "MIT",
       "peerDependencies": {
-        "@typedly/settings": "^0.2.0"
+        "@typedly/settings": "^0.3.0"
       }
     },
-    "node_modules/@typedly/settings": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@typedly/settings/-/settings-0.2.0.tgz",
-      "integrity": "sha512-U4iiHGLv2ymMqMIASwOjUoTiaf+pDKfE4uPAhxVQbZj2GEyuxjSdLeGhq8CEyWGKhWC7xx9xcu/skRUBKp7sCA==",
+    "node_modules/@typedly/length": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@typedly/length/-/length-0.1.1.tgz",
+      "integrity": "sha512-FflN7srj5Lr9g5hGjzl3+YnZnYiU8d8GlXzWrdNz2D3RRVBPOx/yXEw86//mR9J04rfuwpvW2yNSBf7+qtlFOQ==",
       "funding": [
         {
           "type": "stripe",
@@ -38,6 +38,44 @@
       ],
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@typedly/pattern": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@typedly/pattern/-/pattern-1.0.0.tgz",
+      "integrity": "sha512-9E3BkLoW89honN75HS7jgseDlSGPvBX8nNd80Mud9WAIwJyE7kGSS+iJjakzYoJO961W4XPyWUdXc6OhA5D7sg==",
+      "funding": [
+        {
+          "type": "stripe",
+          "url": "https://donate.stripe.com/dR614hfDZcJE3wAcMM"
+        },
+        {
+          "type": "revolut",
+          "url": "https://checkout.revolut.com/pay/048b10a3-0e10-42c8-a917-e3e9cb4c8e29"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@typedly/settings": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@typedly/settings/-/settings-0.3.0.tgz",
+      "integrity": "sha512-PnH3D1+0+ZVIojkO5zn2Pz4RUY7h2eGjkn6jq/LWS7c9+621OmgDJOq1Sqb+jNWIkR8m5Q17VdDbjBewhUkthg==",
+      "funding": [
+        {
+          "type": "stripe",
+          "url": "https://donate.stripe.com/dR614hfDZcJE3wAcMM"
+        },
+        {
+          "type": "revolut",
+          "url": "https://checkout.revolut.com/pay/048b10a3-0e10-42c8-a917-e3e9cb4c8e29"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@typedly/length": "^0.1.1",
+        "@typedly/pattern": "^1.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typedly/affix",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": "wwwdev.io <dev@wwwdev.io>",
   "description": "A TypeScript type definitions package for affix.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "peerDependencies": {
-    "@typedly/settings": "^0.2.0"
+    "@typedly/settings": "^0.3.0"
   },
   "scripts": {
     "prepublishOnly": "npm install rimraf && npm run pkg && npm run clean",

--- a/src/interface/affix-options.interface.ts
+++ b/src/interface/affix-options.interface.ts
@@ -12,14 +12,16 @@ import { BasicAffixKind } from "../type";
  * @template {number | undefined} [Min=number | undefined] The type of the min property, defaults to `number | undefined`.
  * @template {number | undefined} [Max=number | undefined] The type of the max property, defaults to `number | undefined`.
  * @template {RegExp | string | undefined} [Pattern=RegExp | string | undefined] The type of the pattern property, defaults to `RegExp | string | undefined`.
- * @extends {Partial<AffixSettings<
- *   Value,
- *   Kind,
- *   Length,
- *   Min,
- *   Max,
- *   Pattern
- * >>}
+ * @extends {Partial<AffixSettings<Value, Kind, Length, Min, Max, Pattern>>}
+ * @example
+ * const example1: AffixOptions = {
+ *  kind: 'prefix',
+ *  lowercase: true,
+ *  uppercase: false,
+ *  special: false,
+ *  whitespace: false,
+ *  numeric: false
+ * };
  */
 export interface AffixOptions<
   Value extends string | undefined = string | undefined,

--- a/src/interface/affix-settings.interface.ts
+++ b/src/interface/affix-settings.interface.ts
@@ -1,5 +1,5 @@
 // Interface.
-import { LengthSetting, PatternSetting, ValueSetting } from '@typedly/settings';
+import { LengthSetting, PatternSettings, ValueSetting } from '@typedly/settings';
 // Type.
 import { BasicAffixKind } from '../type';
 /**
@@ -12,7 +12,10 @@ import { BasicAffixKind } from '../type';
  * @template {number | undefined} [Min=number | undefined] The type of min of generic type `Min`.
  * @template {number | undefined} [Max=number | undefined] The type of max of generic type `Max`.
  * @template {RegExp | string | undefined} [Pattern=RegExp | string | undefined] The type of pattern of generic type `Pattern`.
- * @extends {Settings<Value, Length, Min, Max, Pattern>}
+ * @extends {ValueSetting<Value>}
+ * @extends {LengthSetting<Length, Min, Max>}
+ * @extends {PatternSettings<Pattern>}
+ * @extends {Omit<PatternSettings<Pattern>, 'regexp'>}
  */
 export interface AffixSettings<
   Value extends string | undefined = string | undefined,
@@ -24,6 +27,8 @@ export interface AffixSettings<
 > extends
   ValueSetting<Value>,
   LengthSetting<Length, Min, Max>,
-  PatternSetting<Pattern> {
-  kind: Kind | undefined;
+  Omit<PatternSettings<Pattern>, 'regexp'> {
+    digit: boolean | undefined;
+    kind: Kind | undefined;
+    pattern: Pattern | undefined;
 }

--- a/src/interface/affix-settings.interface.ts
+++ b/src/interface/affix-settings.interface.ts
@@ -1,5 +1,7 @@
 // Interface.
-import { LengthSetting, PatternSettings, ValueSetting } from '@typedly/settings';
+import { ValueSetting } from '@typedly/settings';
+import { LengthSetting } from '@typedly/length';
+import { PatternSettings } from '@typedly/pattern';
 // Type.
 import { BasicAffixKind } from '../type';
 /**

--- a/src/interface/affix-settings.interface.ts
+++ b/src/interface/affix-settings.interface.ts
@@ -29,6 +29,6 @@ export interface AffixSettings<
   LengthSetting<Length, Min, Max>,
   Omit<PatternSettings<Pattern>, 'regexp'> {
     digit: boolean | undefined;
-    kind: Kind | undefined;
-    pattern: Pattern | undefined;
+    kind: Kind;
+    pattern: Pattern;
 }

--- a/src/interface/affix-settings.interface.ts
+++ b/src/interface/affix-settings.interface.ts
@@ -12,10 +12,22 @@ import { BasicAffixKind } from '../type';
  * @template {number | undefined} [Min=number | undefined] The type of min of generic type `Min`.
  * @template {number | undefined} [Max=number | undefined] The type of max of generic type `Max`.
  * @template {RegExp | string | undefined} [Pattern=RegExp | string | undefined] The type of pattern of generic type `Pattern`.
- * @extends {ValueSetting<Value>}
- * @extends {LengthSetting<Length, Min, Max>}
- * @extends {PatternSettings<Pattern>}
- * @extends {Omit<PatternSettings<Pattern>, 'regexp'>}
+ * @extends {ValueSetting<Value>} The value setting interface for the affix settings.
+ * @extends {LengthSetting<Length, Min, Max>} The length setting interface for the affix settings.
+ * @extends {Omit<PatternSettings<Pattern>, 'regexp'>} The omitted pattern settings interface for the affix settings.
+ * @example
+ * const example1: AffixSettings = {
+ *  value: 'example',
+ *  kind: 'prefix',
+ *  length: { value: 7, min: 3, max: 10 },
+ *  digit: true,
+ *  pattern: /^[a-z0-9]+$/,
+ *  lowercase: true,
+ *  uppercase: false,
+ *  special: false,
+ *  whitespace: false,
+ *  numeric: false,
+ * };
  */
 export interface AffixSettings<
   Value extends string | undefined = string | undefined,
@@ -31,4 +43,5 @@ export interface AffixSettings<
     digit: boolean | undefined;
     kind: Kind;
     pattern: Pattern;
+    whitespace: boolean | undefined;
 }

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -9,11 +9,19 @@ export type {
 } from './interface';
 
 export type {
+  // Kind.
   Adfix,
-  AdfixTemplate,
-  AdfixTuple,
   AffixKind,
   BasicAffixKind,
   HypotheticalAffixKind,
   SuprasegmentalAffixKind,
+  // Tuple.
+  AdfixTuple,
+  // Template.
+  AdfixTemplate,
+  CircumfixTemplate,
+  InfixTemplate,
+  InterfixTemplate,
+  PrefixTemplate,
+  SuffixTemplate,
 } from './type';

--- a/src/test/affix-configuration.spec.ts
+++ b/src/test/affix-configuration.spec.ts
@@ -7,6 +7,12 @@ const affixConfiguration1: AffixConfiguration<'example', 'circumfix', 27> = {
   length: 27,
   pattern: /^[a-zA-Z]+$/,
   timestamp: new Date(),
+  digit: false,
+  lowercase: true,
+  uppercase: true,
+  special: true,
+  whitespace: false,
+  numeric: false,
 };
 
 // Full configuration with length and pattern settings.
@@ -18,11 +24,12 @@ const affixConfiguration2: AffixConfiguration<'example', 'prefix', 27, 27, 34> =
     min: 27,
     max: 34 
   },
-  pattern: {
-    regexp: /^[a-zA-Z]+$/,
-    lowercase: true,
-    uppercase: true,
-    special: true,
-  },
+  pattern: /^[a-zA-Z]+$/,
   timestamp: new Date(),
+  digit: false,
+  lowercase: true,
+  uppercase: true,
+  special: true,
+  whitespace: false,
+  numeric: false,
 };

--- a/src/test/affix-settings.spec.ts
+++ b/src/test/affix-settings.spec.ts
@@ -6,12 +6,13 @@ const settings1: AffixSettings<'example', 'infix', 33, 27, 34, RegExp> = {
   length: {
     value: 33,
     min: 27,
-    max: 34 
+    max: 34
   },
-  pattern: {
-    regexp: /^[a-zA-Z]+$/,
-    lowercase: true,
-    uppercase: true,
-    special: true,
-  },
+  pattern: /^[a-zA-Z]+$/,
+  digit: false,
+  lowercase: true,
+  uppercase: true,
+  special: true,
+  whitespace: false,
+  numeric: false,
 };

--- a/src/type/adfix-template.type.ts
+++ b/src/type/adfix-template.type.ts
@@ -1,14 +1,22 @@
+// Type.
+import { PrefixTemplate } from "./prefix-template.type";
+import { SuffixTemplate } from "./suffix-template.type";
 /**
  * @description The type defines the basic structure of adfix template where the prefix, stem, and suffix are separated by a delimiter.
  * @export
- * @template {string} Prefix The prefix part of the adfix template.
- * @template {string} Stem The stem part of the adfix template.
- * @template {string} Suffix The suffix part of the adfix template.
- * @template {string} Delimiter The delimiter used to separate the prefix, stem, and suffix.
+ * @template {string} [Prefix=string] The prefix part of the adfix template.
+ * @template {string} [Stem=string] The stem part of the adfix template.
+ * @template {string} [Suffix=string] The suffix part of the adfix template.
+ * @template {string} [PrefixDelimiter=''] The delimiter used to separate the prefix from the stem.
+ * @template {string} [SuffixDelimiter=PrefixDelimiter] The delimiter used to separate the stem from the suffix.
+ * @example
+ * const example1: AdfixTemplate<'pre', 'fix', 'post'> = "prefixpost";
+ * const example2: AdfixTemplate<'pre', 'fix', 'post', '-', '_'> = "pre-fix_post";
  */
 export type AdfixTemplate<
   Prefix extends string = string,
   Stem extends string = string,
   Suffix extends string = string,
-  Delimiter extends string = string
-> = `${Prefix}${Delimiter}${Stem}${Delimiter}${Suffix}`;
+  PrefixDelimiter extends string = '',
+  SuffixDelimiter extends string = PrefixDelimiter,
+> = `${PrefixTemplate<Prefix, Stem, PrefixDelimiter>}${SuffixTemplate<'', Suffix, SuffixDelimiter>}`;

--- a/src/type/circumfix-template.type.ts
+++ b/src/type/circumfix-template.type.ts
@@ -1,0 +1,19 @@
+// Type.
+import { AdfixTemplate } from "./adfix-template.type";
+/**
+ * @description Represents a template for constructing a string with circumfix inserted at the beginning and end of the stem.
+ * @export
+ * @template {string} CircumfixStart The circumfix of the stem.
+ * @template {string} Stem The stem between the circumfix.
+ * @template {string} [CircumfixEnd=CircumfixStart] The circumfix at the end of the stem, defaults to the same as `CircumfixStart`.
+ * @template {string} [Delimiter=''] The delimiter between circumfix and stem.
+ * @example
+ * // CircumfixTemplate<'en', 'light'> results in "enlighten"
+ * // CircumfixTemplate<'', 'stem', '', '-'> results in "-stem-"
+ */
+export type CircumfixTemplate<
+  CircumfixStart extends string,
+  Stem extends string,
+  CircumfixEnd extends string = CircumfixStart,
+  Delimiter extends string = ''
+> = AdfixTemplate<CircumfixStart, Stem, CircumfixEnd, Delimiter>;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,7 +1,14 @@
 export type { Adfix } from './adfix.type';
-export type { AdfixTemplate } from './adfix-template.type';
 export type { AdfixTuple } from './adfix-tuple.type';
 export type { AffixKind } from './affix-kind.type';
 export type { BasicAffixKind } from './basic-affix-kind.type';
 export type { HypotheticalAffixKind } from './hypothetical-affix-kind.type';
 export type { SuprasegmentalAffixKind } from './suprasegmental-affix-kind.type';
+
+// Template.
+export type { AdfixTemplate } from './adfix-template.type';
+export type { CircumfixTemplate } from './circumfix-template.type';
+export type { InfixTemplate } from './infix-template.type';
+export type { InterfixTemplate } from './interfix-template.type';
+export type { PrefixTemplate } from './prefix-template.type';
+export type { SuffixTemplate } from './suffix-template.type';

--- a/src/type/infix-template.type.ts
+++ b/src/type/infix-template.type.ts
@@ -1,0 +1,17 @@
+/**
+ * @description Represents a template for constructing a string with an infix inserted between two stem halves.
+ * @export
+ * @template {string} StemStart The start part of the stem.
+ * @template {string} Infix The infix to insert.
+ * @template {string} StemEnd The end part of the stem.
+ * @template {string} [Delimiter=''] The delimiter between infix and stem parts.
+ */
+export type InfixTemplate<
+  StemStart extends string,
+  Infix extends string,
+  StemEnd extends string,
+  Delimiter extends string = ''
+> = `${StemStart}${Delimiter}${Infix}${Delimiter}${StemEnd}`;
+
+// export type Inserted = InfixTemplate<'stem', 'in', 'em'>;      // "stinem"
+// export type InsertedDash = InfixTemplate<'stem', 'in', 'em', '-'>; // "st-in-em"

--- a/src/type/interfix-template.type.ts
+++ b/src/type/interfix-template.type.ts
@@ -1,0 +1,17 @@
+/**
+ * @description Represents a template for constructing a string with an interfix inserted between two stems.
+ * @export
+ * @template {string} FirstStem The first stem.
+ * @template {string} Interfix The interfix to insert.
+ * @template {string} SecondStem The second stem.
+ * @template {string} [Delimiter=''] The delimiter between stems.
+ * @example
+ * const example1 = InterfixTemplate<'arbeit', 's', 'zimmer'>; // results in "arbeitszimmer"
+ * const example2 = InterfixTemplate<'work', '-', 'room'>; // results in "work-room"
+ */
+export type InterfixTemplate<
+  FirstStem extends string,
+  Interfix extends string,
+  SecondStem extends string,
+  Delimiter extends string = ''
+> = `${FirstStem}${Delimiter}${Interfix}${Delimiter}${SecondStem}`;

--- a/src/type/prefix-template.type.ts
+++ b/src/type/prefix-template.type.ts
@@ -1,0 +1,12 @@
+/**
+ * @description Represents a template for constructing a prefixed string.
+ * @export
+ * @template {string} Prefix The type of the prefix.
+ * @template {string} Stem The type of the stem.
+ * @template {string} [Delimiter=''] The type of the delimiter.
+ */
+export type PrefixTemplate<
+  Prefix extends string,
+  Stem extends string,
+  Delimiter extends string = '',
+> = `${Prefix}${Delimiter}${Stem}`;

--- a/src/type/suffix-template.type.ts
+++ b/src/type/suffix-template.type.ts
@@ -1,0 +1,15 @@
+/**
+ * @description Represents a template for constructing a prefixed string.
+ * @export
+ * @template {string} Stem The type of the stem.
+ * @template {string} Suffix The type of the suffix.
+ * @template {string} [Delimiter=''] The type of the delimiter.
+ * @example
+ * const example1 = SuffixTemplate<'stem', 'suffix'>; // results in "stemsuffix"
+ * const example2 = SuffixTemplate<'stem', 'suffix', '-'>; // results in "stem-suffix"
+ */
+export type SuffixTemplate<
+  Stem extends string,
+  Suffix extends string,
+  Delimiter extends string = '',
+> = `${Stem}${Delimiter}${Suffix}`;


### PR DESCRIPTION
## v4.0.0

- Add templates `CircumfixTemplate`, `InfixTemplate`, `InterfixTemplate`, `PrefixTemplate`, and `SuffixTemplate`. 291f8f9f31b8cff209ddf0765ae674d4c7f9d654
- Flatten the affix pattern settings. b853014cb2beb73a5a885deeb340735f1baeb826
- Add `digit`, `whitespace`, and omit `regexp`.
- Update `AdfixTemplate` to use delimiter for prefix and suffix. 6afb4dcc8bf04b00d0b2b1c7fb1c78140a525673